### PR TITLE
CountryListServiceProvider.php

### DIFF
--- a/src/Monarobase/CountryList/CountryListServiceProvider.php
+++ b/src/Monarobase/CountryList/CountryListServiceProvider.php
@@ -39,9 +39,8 @@ class CountryListServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['countrylist'] = $this->app->share(function($app)
-		{
-			return new CountryList;
+		$this->app->bind('countrylist', function ($app) {
+            		return new CountryList();
 		});
 	}
 


### PR DESCRIPTION
Illuminate\Foundation\Application::share() is deprecated.
Proposed change to accommodate new versions of Laravel 5.x. 
In Laravel 5.4 Illuminate\Foundation\Application::share() has been removed directly.
Cheers.